### PR TITLE
Fixing the AudioToolbox lib name.

### DIFF
--- a/DCPathButton.podspec
+++ b/DCPathButton.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   s.resources  = ["DCPathButton/Sounds/*"]
 
-  s.frameworks = 'QuartzCore','AudioToolBox'
+  s.frameworks = 'QuartzCore','AudioToolbox'
 
   s.requires_arc = true
 


### PR DESCRIPTION
There is a typo in the AudioToolbox framework name which breaks the build with pods integration. Most probably because my partition has case sensitive format type.